### PR TITLE
add required kwarg for zarr.open

### DIFF
--- a/bsccm/_version.py
+++ b/bsccm/_version.py
@@ -1,2 +1,2 @@
-version_info = (1, 2, 0)
+version_info = (1, 2, 1)
 __version__ = ".".join(map(str, version_info))

--- a/bsccm/bsccm.py
+++ b/bsccm/bsccm.py
@@ -181,7 +181,7 @@ class BSCCM:
         if data_root[-1] != os.sep:
             data_root += os.sep
         self.data_root = data_root
-        self.zarr_dataset = zarr.open(data_root + 'BSCCM_images.zarr', 'r')
+        self.zarr_dataset = zarr.open(data_root + 'BSCCM_images.zarr', mode='r')
         self.index_dataframe = pd.read_csv(data_root + 'BSCCM_index.csv', low_memory=not cache_index, index_col='global_index')
         self.size = len(self.index_dataframe)
         self.fluor_channel_names = self.global_metadata['fluorescence']['channel_names']
@@ -189,7 +189,7 @@ class BSCCM:
         if 'BSCCM_surface_markers.csv' in os.listdir(data_root):
             self.surface_marker_dataframe = pd.read_csv(data_root + 'BSCCM_surface_markers.csv', index_col='global_index')
         if 'BSCCM_backgrounds.zarr' in os.listdir(data_root):
-            self.backgrounds_and_shading = zarr.open(data_root + 'BSCCM_backgrounds.zarr', 'r')
+            self.backgrounds_and_shading = zarr.open(data_root + 'BSCCM_backgrounds.zarr', mode='r')
         print('Opened {}'.format(str(self)))
 
         #TODO: add width and height


### PR DESCRIPTION
@henrypinkard  Hi Henry

I was using this package recently and noticed that `zarr>=3.0` requires a keyword-argument for `mode` in `zarr.open`. [Here](https://github.com/zarr-developers/zarr-python/blob/v3.0.0/src/zarr/api/synchronous.py#L155) is the change in `v3.0.0` that make this required. The most recent [code](https://github.com/zarr-developers/zarr-python/blob/v2.18.7/zarr/convenience.py#L44) on `v2.x.x` has `mode` as optional. 

It looks like zarr-python 3 comes with some significant changes, but not any that would impact this pacakge. Everything seemed to work fine once I made this change, and it should be backwards compatible with `zarr>=2,<3`.

Cheers,
Sean